### PR TITLE
Update decorators.py

### DIFF
--- a/django_jsonp/decorators.py
+++ b/django_jsonp/decorators.py
@@ -5,7 +5,7 @@ import types
 
 from django.views.decorators.http import require_GET
 from django.views.generic import View
-from django_jsonp.response import get_jsonp_response
+from .response import get_jsonp_response
 
 from .utils import get_callback
 


### PR DESCRIPTION
fix bugs. When package name changed, original can not work. Use relative import.
